### PR TITLE
Fix mention of packages for new order.

### DIFF
--- a/chapters/getting-started/working-with-files.qmd
+++ b/chapters/getting-started/working-with-files.qmd
@@ -241,9 +241,8 @@ than a guarantee.
 [jpg]: https://en.wikipedia.org/wiki/JPEG
 
 R has built-in functions for reading a variety of formats. The R community also
-provides **packages**, shareable and reusable pieces of code, to read even more
-formats. You'll learn more about packages later, in @sec-packages. For now,
-let's focus on datasets that can be read with R's built-in functions.
+provides packages (@sec-packages) to read even more formats. For now, let's
+focus on datasets that can be read with R's built-in functions.
 
 Here are several formats that are frequently used to distribute data, along
 with the name of a built-in function or contributed package that can read the


### PR DESCRIPTION
The section about packages is now near the beginning. This commit updates some text that incorrectly said it's near the end.